### PR TITLE
fix: allow negative activeOffsetX

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -807,7 +807,7 @@ const ModalizeBase = (
         onGestureEvent={handleGestureEvent}
         minDist={minDist}
         activeOffsetY={ACTIVATED}
-        activeOffsetX={ACTIVATED}
+        activeOffsetX={[-ACTIVATED, ACTIVATED]}
         onHandlerStateChange={handleChildren}
       >
         <Animated.View style={[style, childrenStyle]}>


### PR DESCRIPTION
### **Issue: can not swipe to open modal**

**Description**: This pull request fixes a bug where users were unable to open the modal by swiping from the bottom right to the top left. With this update, the modal can now be opened using a swipe gesture from the bottom right corner upwards to the top left, improving the gesture detection and user experience.


